### PR TITLE
TML-44214 Make PDO compatible with behaviour prior to PHP8

### DIFF
--- a/library/Zend/Db/Adapter/Pdo/Abstract.php
+++ b/library/Zend/Db/Adapter/Pdo/Abstract.php
@@ -311,6 +311,9 @@ abstract class Zend_Db_Adapter_Pdo_Abstract extends Zend_Db_Adapter_Abstract
     protected function _commit()
     {
         $this->_connect();
+        if (!$this->_connection->inTransaction()) {
+            return;
+        }
         $this->_connection->commit();
     }
 
@@ -319,6 +322,9 @@ abstract class Zend_Db_Adapter_Pdo_Abstract extends Zend_Db_Adapter_Abstract
      */
     protected function _rollBack() {
         $this->_connect();
+        if (!$this->_connection->inTransaction()) {
+            return;
+        }
         $this->_connection->rollBack();
     }
 


### PR DESCRIPTION
See https://www.php.net/manual/en/migration80.incompatible.php#migration80.incompatible.pdo-mysql
We rely in too many places on behaviour like it was before PHP8, so this seems to be the only way to make behaviour backward compatible. 